### PR TITLE
Fixed two (Windows) issues

### DIFF
--- a/bin/ng-html2js
+++ b/bin/ng-html2js
@@ -16,7 +16,7 @@ var argv = optimist.usage('Usage: $0 <input file> <output file>')
     .alias('m', 'module')
     .string('m')
     .describe('m', 'If module name is provided, template will be packaged under this module.')
-	 // -b, --basedir option
+    // -b, --basedir option
     .alias('b', 'basedir')
     .string('b')
     .describe('b', 'If basedir is provided, basedir will be removed from the templates\' path.')
@@ -43,7 +43,7 @@ var baseDir = argv.b;
 var content = fs.readFileSync(inputFile, 'utf8');
 var inputAlias = inputFile;
 if(baseDir){
-	inputAlias = inputAlias.replace(baseDir, '/');
+  inputAlias = inputAlias.replace(baseDir, '/');
 }
 inputAlias = inputAlias.replace(/\\/g, '/');
 var output = html2js(inputAlias, content, moduleName);


### PR DESCRIPTION
I ran into two issues when using ng-html2js. One issue is a Windows specific issue, the other one might or might not be an issue on Linux, I'm not sure.
These issues are:
1. Relative paths don't work (at least under Windows). When using absolute paths, the absolute path ends up in the template name.
2. When template names contain directories, they should be separated with '/' instead of '\' (Windows only issue).

These issues are fixed as follows:
1. Added an 'baseDir' option. 'baseDir' is subtracted from the template name. This way you can use absolute file names, while the template name will become the abolute url.
  Example:

```
  ng-html2js "C:\projects\myProject\partials\views\blah.html" -b C:\projects\myProject\ -m myApp.templates
```

  Would result in a template name of '/partials/views/blah.html'.
2. The '\'-es in the template name are replaced by '/'.
